### PR TITLE
Change extension category to `SCM Providers`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "icon": "icon.svg",
   "enableProposedApi": false,
   "categories": [
-    "Other"
+    "SCM Providers"
   ],
   "activationEvents": [
     "*"


### PR DESCRIPTION
VSCode could automatically drive users to discover new SCM Providers in the Marketplace. For this, we need the extensions to have the correct category.

Related to Microsoft/vscode#25696