### PR TITLE
fix: correctly open conflicted files, diff view on click

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -934,7 +934,7 @@ export class Repository implements IDisposable {
 
     async show(ref: string, filePath: string): Promise<string> {
         // TODO@Joao: should we make this a general concept?
-        await this.whenIdleAndFocused();
+        //await this.whenIdleAndFocused();
 
         return await this.run(Operation.Show, async () => {
             const relativePath = path.relative(this.repository.root, filePath).replace(/\\/g, '/');

--- a/src/util.ts
+++ b/src/util.ts
@@ -134,7 +134,7 @@ export async function mkdirp(path: string, mode?: number): Promise<boolean> {
 			if (err.code === 'EEXIST') {
 				const stat = await nfcall<fs.Stats>(fs.stat, path);
 
-				if (stat.isDirectory) {
+				if (stat.isDirectory()) {
 					return;
 				}
 


### PR DESCRIPTION
Fixes the error when clicking on the conflicted file which fails to open diff view. Further improvements to diff view needed, but this basically fixes the most frustrating issue.