### PR TITLE
Enforce default output for all hg commands

### DIFF
--- a/src/hg.ts
+++ b/src/hg.ts
@@ -164,7 +164,7 @@ export class HgFinder {
 		});
 	}
 
-	private findMercurialWin32(base: string): Promise<IHg> {
+	private findMercurialWin32(base: string | undefined): Promise<IHg> {
 		if (!base) {
 			return Promise.reject<IHg>('Not found');
 		}
@@ -172,7 +172,7 @@ export class HgFinder {
 		return this.findSpecificHg(path.join(base, 'Mercurial', 'hg.exe'));
 	}
 
-	private findTortoiseHgWin32(base: string): Promise<IHg> {
+	private findTortoiseHgWin32(base: string | undefined): Promise<IHg> {
 		if (!base) {
 			return Promise.reject<IHg>('Not found');
 		}

--- a/src/hg.ts
+++ b/src/hg.ts
@@ -507,7 +507,7 @@ export class Hg {
 			...process.env,
 			...options.env,
 			VSCODE_HG_COMMAND: args[0],
-			LC_ALL: 'en_US',
+			LC_ALL: 'en_US.UTF-8',
 			LANG: 'en_US.UTF-8'
 		}
 

--- a/src/hg.ts
+++ b/src/hg.ts
@@ -504,6 +504,7 @@ export class Hg {
 
 		options.env = {
 			HGENCODING: "utf-8", // allow user's env to overwrite this
+			HGPLAIN: '',
 			...process.env,
 			...options.env,
 			VSCODE_HG_COMMAND: args[0],

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1149,7 +1149,7 @@ export class Repository implements IDisposable {
 
         const groupInput: IGroupStatusesParams = {
             respositoryRoot: this.repository.root,
-            fileStatuses: fileStatuses,
+            fileStatuses: fileStatuses || [],
             repoStatus: this._repoStatus,
             resolveStatuses: resolveStatuses,
             statusGroups: this._groups

--- a/src/util.ts
+++ b/src/util.ts
@@ -134,7 +134,7 @@ export async function mkdirp(path: string, mode?: number): Promise<boolean> {
 			if (err.code === 'EEXIST') {
 				const stat = await nfcall<fs.Stats>(fs.stat, path);
 
-				if (stat.isDirectory) {
+				if (stat.isDirectory()) {
 					return;
 				}
 


### PR DESCRIPTION
Sets an HGPLAIN flag that disables user customizations that affect output. See https://www.selenic.com/mercurial/hg.1.html#environment-variables.