### PR TITLE
#50: Fix for file history commands

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -141,12 +141,12 @@ export class CommandCenter {
 		if (resource.mergeStatus === MergeStatus.UNRESOLVED &&
 			resource.status !== Status.MISSING &&
 			resource.status !== Status.DELETED) {
-			return resource.resourceUri.with({ scheme: 'hg', query: 'p2()' });
+			return toHgUri(resource.resourceUri, 'p2()');
 		}
 
 		switch (resource.status) {
 			case Status.DELETED:
-				return resource.resourceUri.with({ scheme: 'hg', query: '.' });
+				return toHgUri(resource.resourceUri, '.');
 
 			case Status.ADDED:
 			case Status.IGNORED:
@@ -1090,8 +1090,8 @@ export class CommandCenter {
 
 	private async diffFile(repository: Repository, rev1: Revision, rev2: Revision, file: IFileStatus) {
 		const uri = repository.toUri(file.path);
-		const left = uri.with({ scheme: 'hg', query: rev1.hash });
-		const right = uri.with({ scheme: 'hg', query: rev2.hash });
+		const left = toHgUri(uri, rev1.hash);
+		const right = toHgUri(uri, rev2.hash);
 		const baseName = path.basename(uri.fsPath);
 		const title = `${baseName} (#${rev1.revision} vs. ${rev2.revision})`;
 
@@ -1101,7 +1101,8 @@ export class CommandCenter {
 	}
 
 	private async diff(commit: Commit, uri: Uri) {
-		const left = uri.with({ scheme: 'hg', query: commit.hash });
+		const query = { path: uri.fsPath, ref: commit.hash };
+		const left = toHgUri(uri, commit.hash);
 		const right = uri;
 		const baseName = path.basename(uri.fsPath);
 		const title = `${baseName} (#${commit.revision} vs. local)`;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1101,7 +1101,6 @@ export class CommandCenter {
 	}
 
 	private async diff(commit: Commit, uri: Uri) {
-		const query = { path: uri.fsPath, ref: commit.hash };
 		const left = toHgUri(uri, commit.hash);
 		const right = uri;
 		const baseName = path.basename(uri.fsPath);

--- a/src/contentProvider.ts
+++ b/src/contentProvider.ts
@@ -40,7 +40,6 @@ export class HgContentProvider {
 			model.onDidChangeRepository(this.eventuallyFireChangeEvents, this),
 			model.onDidChangeOriginalResource(this.onDidChangeOriginalResource, this),
 			workspace.registerTextDocumentContentProvider('hg', this),
-			workspace.registerTextDocumentContentProvider('hg-original', this)
 		);
 
 		setInterval(() => this.cleanup(), FIVE_MINUTES);
@@ -102,10 +101,6 @@ export class HgContentProvider {
 		const cacheValue = { uri, timestamp };
 
 		this.cache[cacheKey] = cacheValue;
-
-		if (uri.scheme === 'hg-original') {
-			uri = uri.with({ scheme: 'hg', path: uri.query });
-		}
 
 		let { path, ref } = fromHgUri(uri);
 

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -446,7 +446,7 @@ export class Repository implements IDisposable {
 
         // As a mitigation for extensions like ESLint showing warnings and errors
         // for hg URIs, let's change the file extension of these uris to .hg.
-        return toHgUri(uri, '', true);
+        return toHgUri(uri, '.', true);
     }
 
     @throttle

--- a/src/uri.ts
+++ b/src/uri.ts
@@ -8,7 +8,12 @@
 
 import { Uri } from 'vscode';
 
-export function fromHgUri(uri: Uri): { path: string; ref: string; } {
+export interface HgUriParams {
+	path: string;
+	ref: string;
+}
+
+export function fromHgUri(uri: Uri): HgUriParams {
 	return JSON.parse(uri.query);
 }
 
@@ -16,12 +21,20 @@ export function fromHgUri(uri: Uri): { path: string; ref: string; } {
 // for hg URIs, let's change the file extension of these uris to .hg,
 // when `replaceFileExtension` is true.
 export function toHgUri(uri: Uri, ref: string, replaceFileExtension = false): Uri {
+	const params: HgUriParams = {
+		path: uri.fsPath,
+		ref
+	};
+
+	let path = uri.path;
+
+	if (replaceFileExtension) {
+		path = `${path}.hg`
+	}
+
 	return uri.with({
-		scheme: 'hg-original',
-		path: replaceFileExtension ? `${uri.path}.hg` : uri.path,
-		query: JSON.stringify({
-			path: uri.fsPath,
-			ref
-		})
+		scheme: 'hg',
+		path,
+		query: JSON.stringify(params)
 	});
 }


### PR DESCRIPTION
The actual fix is in commands.ts:1104, but there were a few places where Uris were being manipulated ad-hoc instead of using `toHgUri` and `fromHgUri`.