### PR TITLE
Fix #116: Show 'heads(draft())' and 'max(public())' revisions in "Hg: Update to..."

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1082,8 +1082,7 @@ export class CommandCenter {
         const uncleanBookmarks =
             useBookmarks && (!isClean || (repoStatus && repoStatus.isMerge));
 
-        const refs = await this.getUpdateCandidates(
-            repository,
+        const refs = await repository.getUpdateCandidates(
             useBookmarks,
             uncleanBookmarks
         );
@@ -1103,43 +1102,6 @@ export class CommandCenter {
 
         if (choice) {
             await choice.run(repository);
-        }
-    }
-
-    private async getUpdateCandidates(
-        repository: Repository,
-        useBookmarks: boolean,
-        uncleanBookmarks?: boolean
-    ): Promise<Ref[]> {
-        if (useBookmarks) {
-            // bookmarks
-            if (uncleanBookmarks) {
-                // unclean: only allow bookmarks already on the parents
-                const [bookmarks, parents] = await Promise.all([
-                    repository.getBookmarks(),
-                    repository.getParents(),
-                ]);
-                return bookmarks.filter((b) =>
-                    parents.some((p) => p.hash.startsWith(b.commit!))
-                );
-            } else {
-                // clean: allow all bookmarks and other commits
-                const [bookmarks, maxPublic, draftHeads] = await Promise.all([
-                    repository.getBookmarks(),
-                    repository.getPublicTip({ excludeBookmarks: true }),
-                    repository.getDraftHeads({ excludeBookmarks: true }),
-                ]);
-                return [...bookmarks, ...maxPublic, ...draftHeads];
-            }
-        } else {
-            // branches/tags
-            const [branches, tags, maxPublic, draftHeads] = await Promise.all([
-                repository.getBranches(),
-                repository.getTags(),
-                repository.getPublicTip({ excludeTags: true }),
-                repository.getDraftHeads({ excludeTags: true }),
-            ]);
-            return [...branches, ...tags, ...maxPublic, ...draftHeads];
         }
     }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1093,7 +1093,14 @@ export class CommandCenter {
                 this.focusScm();
                 return;
             }
-            refs = await repository.getBranchesAndTags();
+
+            const [branches, tags, maxPublic, draftHeads] = await Promise.all([
+                repository.getBranches(),
+                repository.getTags(),
+                repository.getPublicTip(),
+                repository.getDraftHeads(),
+            ]);
+            refs = [...branches, ...tags, ...maxPublic, ...draftHeads];
         }
 
         const choice = await interaction.pickUpdateRevision(refs, unclean);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -22,7 +22,6 @@ import {
     TextEditor,
 } from "vscode";
 import {
-    Ref,
     RefType,
     ShelveOptions,
     Hg,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1057,7 +1057,7 @@ export class CommandCenter {
 
         if (typedConfig.useBookmarks) {
             // bookmarks
-            const bookmarkRefs = (await repository.getRefs()) as Bookmark[];
+            const bookmarkRefs = await repository.getBookmarks();
             const { isClean, repoStatus } = repository;
             unclean = !isClean || (repoStatus && repoStatus.isMerge) || false;
             if (unclean) {
@@ -1093,7 +1093,7 @@ export class CommandCenter {
                 this.focusScm();
                 return;
             }
-            refs = await repository.getRefs();
+            refs = await repository.getBranchesAndTags();
         }
 
         const choice = await interaction.pickUpdateRevision(refs, unclean);
@@ -1502,7 +1502,7 @@ export class CommandCenter {
         const bookmarkName = await interaction.inputBookmarkName();
 
         if (bookmarkName) {
-            const bookmarkRefs = await repository.getRefs();
+            const bookmarkRefs = await repository.getBookmarks();
             const existingBookmarks = bookmarkRefs.filter(
                 (ref) => ref.type === RefType.Bookmark
             ) as Bookmark[];
@@ -1546,7 +1546,7 @@ export class CommandCenter {
             }
         }
 
-        const bookmarkRefs = await repository.getRefs();
+        const bookmarkRefs = await repository.getBookmarks();
         const existingBookmarks = bookmarkRefs.filter(
             (ref) => ref.type === RefType.Bookmark
         ) as Bookmark[];

--- a/src/hg.ts
+++ b/src/hg.ts
@@ -1473,13 +1473,13 @@ export class Repository {
         return activeBookmark;
     }
 
-    async getLogEntries({
+    private async getNativeCommits({
         revQuery,
         branch,
         filePaths,
         follow,
         limit,
-    }: LogEntryRepositoryOptions = {}): Promise<Commit[]> {
+    }: LogEntryRepositoryOptions = {}): Promise<NativeCommit[]> {
         const args = ["log", "-T", "json"];
 
         if (revQuery) {
@@ -1503,8 +1503,16 @@ export class Repository {
         }
 
         const result = await this.run(args);
-        const logEntries = JSON.parse(result.stdout.trim()).map(
-            (commit: NativeCommit): Commit | null => {
+        return JSON.parse(result.stdout.trim()) as NativeCommit[];
+    }
+
+    async getLogEntries(
+        options: LogEntryRepositoryOptions = {}
+    ): Promise<Commit[]> {
+        const nativeCommits = await this.getNativeCommits(options);
+
+        return nativeCommits.map(
+            (commit: NativeCommit): Commit => {
                 return {
                     revision: commit.rev,
                     date: new Date(commit.date[0] * 1000),
@@ -1516,7 +1524,6 @@ export class Repository {
                 } as Commit;
             }
         );
-        return logEntries;
     }
 
     async getParents(revision?: string): Promise<Commit[]> {
@@ -1584,6 +1591,38 @@ export class Repository {
             .filter((ref) => !!ref) as Ref[];
 
         return branchRefs;
+    }
+
+    async getDraftHeads(): Promise<Ref[]> {
+        const draftHeads = await this.getNativeCommits({
+            revQuery: "head() and draft()",
+        });
+
+        return draftHeads
+            .filter((c) => c.tags.length === 0)
+            .map((c) => {
+                return {
+                    type: RefType.Commit,
+                    commit: c.node.substr(0, 12),
+                };
+            });
+    }
+
+    async getPublicTip(): Promise<Ref[]> {
+        const maxPublic = await this.getNativeCommits({
+            revQuery: "max(public())",
+            limit: 1,
+        });
+
+        return maxPublic
+            .filter((c) => c.tags.length === 0)
+            .map((c) => {
+                return {
+                    name: "public tip",
+                    type: RefType.Commit,
+                    commit: c.node.substr(0, 12),
+                };
+            });
     }
 
     async getBookmarks(): Promise<Bookmark[]> {

--- a/src/interaction.ts
+++ b/src/interaction.ts
@@ -616,10 +616,13 @@ export namespace interaction {
                   .map((ref) => new UpdateTagItem(ref))
             : [];
 
-        const picks = [...branches, ...bookmarks, ...tags];
-        const revType = useBookmarks ? "bookmark" : "branch/tag";
+        const commits = refs
+            .filter((ref) => ref.type === RefType.Commit)
+            .map((ref) => new UpdateCommitItem(ref));
 
-        const placeHolder = `Select a ${revType} to update to: ${
+        const picks = [...branches, ...bookmarks, ...tags, ...commits];
+
+        const placeHolder = `Select a revision to update to: ${
             unclean
                 ? "(only showing local bookmarks while working directory unclean)"
                 : ""
@@ -1249,7 +1252,8 @@ class UpdateRefItem implements QuickPickItem {
     constructor(protected ref: Ref) {}
 
     async run(repository: Repository): Promise<void> {
-        const ref = this.treeish;
+        const ref =
+            this.ref.type === RefType.Commit ? this.ref.commit : this.treeish;
 
         if (!ref) {
             return;
@@ -1271,6 +1275,12 @@ class UpdateTagItem extends UpdateRefItem {
 class UpdateBookmarkItem extends UpdateRefItem {
     protected get icon(): string {
         return "$(bookmark) ";
+    }
+}
+
+class UpdateCommitItem extends UpdateRefItem {
+    protected get icon(): string {
+        return "$(git-commit) ";
     }
 }
 

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1438,12 +1438,23 @@ export class Repository implements IDisposable {
     }
 
     @throttle
-    public async getBranchesAndTags(): Promise<Ref[]> {
-        const [branches, tags] = await Promise.all([
-            this.repository.getBranches(),
-            this.repository.getTags(),
-        ]);
-        return [...branches, ...tags];
+    public async getBranches(): Promise<Ref[]> {
+        return this.repository.getBranches();
+    }
+
+    @throttle
+    public async getTags(): Promise<Ref[]> {
+        return this.repository.getTags();
+    }
+
+    @throttle
+    public async getDraftHeads(): Promise<Ref[]> {
+        return this.repository.getDraftHeads();
+    }
+
+    @throttle
+    public async getPublicTip(): Promise<Ref[]> {
+        return this.repository.getPublicTip();
     }
 
     @throttle

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -31,6 +31,7 @@ import {
     HgRollbackDetails,
     ShelveOptions,
     UnshelveOptions,
+    GetRefsOptions,
     RefType,
 } from "./hg";
 import {
@@ -1448,13 +1449,13 @@ export class Repository implements IDisposable {
     }
 
     @throttle
-    public async getDraftHeads(): Promise<Ref[]> {
-        return this.repository.getDraftHeads();
+    public async getDraftHeads(opts: GetRefsOptions): Promise<Ref[]> {
+        return this.repository.getDraftHeads(opts);
     }
 
     @throttle
-    public async getPublicTip(): Promise<Ref[]> {
-        return this.repository.getPublicTip();
+    public async getPublicTip(opts: GetRefsOptions): Promise<Ref[]> {
+        return this.repository.getPublicTip(opts);
     }
 
     @throttle

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1433,17 +1433,17 @@ export class Repository implements IDisposable {
     }
 
     @throttle
-    public async getRefs(): Promise<Ref[]> {
-        if (typedConfig.useBookmarks) {
-            const bookmarks = await this.repository.getBookmarks();
-            return bookmarks;
-        } else {
-            const [branches, tags] = await Promise.all([
-                this.repository.getBranches(),
-                this.repository.getTags(),
-            ]);
-            return [...branches, ...tags];
-        }
+    public async getBookmarks(): Promise<Bookmark[]> {
+        return this.repository.getBookmarks();
+    }
+
+    @throttle
+    public async getBranchesAndTags(): Promise<Ref[]> {
+        const [branches, tags] = await Promise.all([
+            this.repository.getBranches(),
+            this.repository.getTags(),
+        ]);
+        return [...branches, ...tags];
     }
 
     @throttle


### PR DESCRIPTION
Demo:
![update draft heads](https://user-images.githubusercontent.com/35645457/86643185-dc571580-bfb2-11ea-9537-03f2506ef6cb.gif)
