### PR TITLE
#166: open non-diff resources with vscode.open

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -170,18 +170,16 @@ export class CommandCenter {
         }
 
         if (!left) {
-            const document = await workspace.openTextDocument(right);
-            await window.showTextDocument(document, opts);
-            return;
+            await commands.executeCommand("vscode.open", right, opts, title);
+        } else {
+            await commands.executeCommand<void>(
+                "vscode.diff",
+                left,
+                right,
+                title,
+                opts
+            );
         }
-
-        return await commands.executeCommand<void>(
-            "vscode.diff",
-            left,
-            right,
-            title,
-            opts
-        );
     }
 
     private getLeftResource(resource: Resource): Uri | undefined {


### PR DESCRIPTION
`vscode.open` does a better job of dealing with binary files than the way we were doing it.