### PR TITLE
docs: typo lineAnnotationEnabled option

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@
     `"cli"` &mdash; spawn a new `hg` process per command (default).
     `"server"` &mdash; run a command server process &nbsp;_i.e. `hg serve --cmdserve`_
 
-`hg.annotationEnabled`
+`hg.lineAnnotationEnabled`
 
 -   Enables `hg annotate` decorations at end of the currently selected lines
 


### PR DESCRIPTION
 [package.json](https://github.com/mrcrowl/vscode-hg/blob/master/package.json#L978) is `lineAnnotationEnabled`, But README.md is `hg.annotationEnabled`.